### PR TITLE
Added support for Marker descriptions

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -82,3 +82,14 @@ def test_dict():
             vol.Required('age'): vol.All(vol.Coerce(int), vol.Range(min=18)),
             vol.Optional('hobby', default='not specified'): str
         }))
+
+
+def test_marker_description():
+    assert [{
+        'name': 'name',
+        'type': 'string',
+        'description': 'Description of name',
+        'required': True,
+    }] == convert(vol.Schema({
+        vol.Required('name', description='Description of name'): str,
+    }))

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -21,13 +21,17 @@ def convert(schema):
         val = []
 
         for key, value in schema.items():
+            description = None
             if isinstance(key, vol.Marker):
                 pkey = key.schema
+                description = key.description
             else:
                 pkey = key
 
             pval = convert(value)
             pval['name'] = pkey
+            if description is not None:
+                pval['description'] = description
 
             if isinstance(key, (vol.Required, vol.Optional)):
                 pval[key.__class__.__name__.lower()] = True


### PR DESCRIPTION
This adds support for `Marker` descriptions released yesterday in voluptuous 0.11.1 (https://github.com/alecthomas/voluptuous/pull/307).

I'm callling `str()` on the description because people may use text-like objects for their descriptions in their schemas (probably rare).