### PR TITLE
Breaking changes: change select options to (key, value) tuple

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -53,7 +53,10 @@ def test_datetime():
 def test_in():
     assert {
         'type': 'select',
-        'options': ['beer', 'wine'],
+        'options': [
+            ('beer', 'beer'),
+            ('wine', 'wine'),
+        ],
     } == convert(vol.Schema(vol.In(['beer', 'wine'])))
 
 
@@ -61,8 +64,8 @@ def test_in_dict():
     assert {
         'type': 'select',
         'options': [
-            {'en_US': 'American English'},
-            {'zh_CN': 'Chinese (Simplified)'},
+            ('en_US', 'American English'),
+            ('zh_CN', 'Chinese (Simplified)'),
         ],
     } == convert(vol.Schema(vol.In(
         {'en_US': 'American English', 'zh_CN': 'Chinese (Simplified)'})))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -61,9 +61,8 @@ def test_in_dict():
     assert {
         'type': 'select',
         'options': [
-            'en_US', 'zh_CN'
-            # {'en_US': 'American English'},
-            # {'zh_CN': 'Chinese (Simplified)'},
+            {'en_US': 'American English'},
+            {'zh_CN': 'Chinese (Simplified)'},
         ],
     } == convert(vol.Schema(vol.In(
         {'en_US': 'American English', 'zh_CN': 'Chinese (Simplified)'})))

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -75,13 +75,12 @@ def convert(schema):
         if isinstance(schema.container, collections.Mapping):
             return {
                 'type': 'select',
-                'options': [{key: value}
-                    for key, value in schema.container.items()]
+                'options': list(schema.container.items()),
             }
         else:
             return {
                 'type': 'select',
-                'options': list(schema.container)
+                'options': [(item, item) for item in schema.container]
             }
 
     elif isinstance(schema, vol.Coerce):

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -72,10 +72,17 @@ def convert(schema):
         }
 
     elif isinstance(schema, vol.In):
-        return {
-            'type': 'select',
-            'options': list(schema.container)
-        }
+        if isinstance(schema.container, collections.Mapping):
+            return {
+                'type': 'select',
+                'options': [{key: value}
+                    for key, value in schema.container.items()]
+            }
+        else:
+            return {
+                'type': 'select',
+                'options': list(schema.container)
+            }
 
     elif isinstance(schema, vol.Coerce):
         schema = schema.type


### PR DESCRIPTION
For dict
```
vol.Schema(vol.In({'key1': 'value1', 'key2': 'value2'})
==>
{
  'type': 'select',
  'options': [
    ('key1', 'value1'),
    ('key2', 'value2'),
  ]
}
```
And it can covert to JSON 
```json
{
  "type": "select",
  "options": [
    ["key1", "value1"],
    ["key2", "value2"]
  ]
}
```

For list, key and value is same
```
vol.Schema(vol.In(['value1', 'value2'])
==>
{
  'type': 'select',
  'options': [
    ('value1', 'value1'),
    ('value2', 'value2'),
  ]
}
```

Therefore, it can better support dropdown selection.